### PR TITLE
feat(analytics): add Google Analytics 4 tracking

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,9 @@ nav:
       - 学習資料: resources/learning-materials.md
 
 extra:
+  analytics:
+    provider: google
+    property: G-XPJ89C33X7
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/fuku-inc/life-science-agent-tutorial


### PR DESCRIPTION
## Summary
- Google Analytics 4（G-XPJ89C33X7）をmkdocs.ymlに追加
- fuku-inc.github.ioとscience-aid.github.io両方のドメインでトラッキング可能

## Test plan
- [ ] GitHub Actionsでのビルドが成功することを確認
- [ ] デプロイ後、GA管理画面でクロスドメイン測定を設定
- [ ] 両ドメインでトラフィックが正しく計測されることを確認

Closes #32

🤖 Generated with [Claude Code](https://claude.ai/code)